### PR TITLE
[enhancements] feed sidebar recommended accounts randomization

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -4,12 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use App\Notifications\NewFollower;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 class FollowController extends Controller
 {
-    public function store(User $user)
+    public function store(Request $request, User $user)
     {
         $authUser = Auth::user();
 
@@ -23,6 +23,9 @@ class FollowController extends Controller
             $authUser->following()->attach($user->id);
             $user->notify(new NewFollower($authUser));
         }
+
+        // Keep sidebar recommendations stable after follow/unfollow to allow immediate undo
+        $request->session()->put('feed_keep_recommendations', true);
 
         return back();
     }


### PR DESCRIPTION
Updated the recommendation flow so the feed sidebar matches the requested behavior:

[FeedController.php]Regenerate recommended users on each page load, but exclude accounts the viewer already follows when building a new set. Added a keep flag so if a follow/unfollow just happened, the existing list is reused (keeps the just-followed account visible for undo).
[FollowController.php] Mark the session to preserve the current recommendations after follow/unfollow actions.
Closes #3 
Kindly review so that i pick on another issue